### PR TITLE
Added missing longDescription fields

### DIFF
--- a/introspection.json
+++ b/introspection.json
@@ -63676,6 +63676,18 @@
             "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
+            "name": "longDescriptionJson",
+            "description": "Long description of the product (JSON).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONString",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `longDescription` field instead."
+          },
+          {
             "name": "thumbnail",
             "description": "The main thumbnail for a product.",
             "args": [
@@ -67746,7 +67758,7 @@
           },
           {
             "name": "longDescriptionJson",
-            "description": "Translated description of the product (JSON).",
+            "description": "Translated long description of the product (JSON).",
             "args": [],
             "type": {
               "kind": "SCALAR",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2933,7 +2933,7 @@
     "string": "Just to let you know... You're in demo mode. You can play around with the dashboard but can't save changes."
   },
   "src_dot_description": {
-    "string": "Description"
+    "string": "Short Description"
   },
   "src_dot_descriptionOptional": {
     "string": "Description (optional)"
@@ -4265,6 +4265,9 @@
   },
   "src_dot_limitReached": {
     "string": "Reached limit for this plan"
+  },
+  "src_dot_longDescription": {
+    "string": "Long Description"
   },
   "src_dot_manage": {
     "context": "button",
@@ -8009,6 +8012,9 @@
   },
   "src_dot_translations_dot_components_dot_TranslationsProductsPage_dot_3468022343": {
     "string": "Search Engine Preview"
+  },
+  "src_dot_translations_dot_components_dot_TranslationsProductsPage_dot_357341910": {
+    "string": "Long Description"
   },
   "src_dot_translations_dot_components_dot_TranslationsProductsPage_dot_4165966072": {
     "context": "attribute list",

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "test:e2e:run": "start-server-and-test start http://localhost:9000 cy:run",
     "test:e2e:run:record": "start-server-and-test start http://localhost:9000 cy:run:record",
     "test:e2e:dev": "start-server-and-test start http://localhost:9000 cy:open",
-    "test": "TZ=UTC jest src/",
+    "test": "SET TZ=UTC && jest src/",
     "transpile-messages": "node scripts/transpile-tx.js",
     "lint": "npx eslint \"src/**/*.@(tsx|ts|jsx|js)\" --fix ; npx prettier --check \"src/**/*.@(tsx|ts|jsx|js)\" --write",
     "postbuild": "rimraf ./build/**/*.js.map",

--- a/schema.graphql
+++ b/schema.graphql
@@ -12163,6 +12163,9 @@ type Product implements Node & ObjectWithMetadata {
   """Description of the product (JSON)."""
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
+  """Long description of the product (JSON)."""
+  longDescriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `longDescription` field instead.")
+
   """The main thumbnail for a product."""
   thumbnail(
     """Size of thumbnail."""
@@ -12931,7 +12934,7 @@ type ProductTranslation implements Node {
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   longDescription: JSONString
 
-  """Translated description of the product (JSON)."""
+  """Translated long description of the product (JSON)."""
   longDescriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `longDescription` field instead.")
 }
 

--- a/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles(
 );
 
 const messages = defineMessages({
-  title: {
+  title2: {
     defaultMessage: "{zonesCount} / {totalCount} shipping zones",
     description: "title"
   }
@@ -62,7 +62,7 @@ const ShippingZonesListHeader: React.FC<ShippingZonesListHeaderProps> = ({
     <div className={classes.container}>
       <AccordionSummary expandIcon={<IconChevronDown />} classes={classes}>
         <Typography variant="subtitle2" color="textSecondary">
-          {intl.formatMessage(messages.title, {
+          {intl.formatMessage(messages.title2, {
             zonesCount: shippingZones.length,
             totalCount
           })}

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -2944,7 +2944,7 @@ export type PreorderThresholdFieldPolicy = {
 	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
 	soldUnits?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ProductKeySpecifier = ('id' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'metadata' | 'metafield' | 'metafields' | 'seoTitle' | 'seoDescription' | 'name' | 'description' | 'longDescription' | 'productType' | 'slug' | 'category' | 'created' | 'updatedAt' | 'chargeTaxes' | 'weight' | 'defaultVariant' | 'rating' | 'channel' | 'descriptionJson' | 'thumbnail' | 'pricing' | 'isAvailable' | 'taxType' | 'attributes' | 'channelListings' | 'mediaById' | 'imageById' | 'variants' | 'media' | 'images' | 'collections' | 'translation' | 'availableForPurchase' | 'availableForPurchaseAt' | 'isAvailableForPurchase' | ProductKeySpecifier)[];
+export type ProductKeySpecifier = ('id' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'metadata' | 'metafield' | 'metafields' | 'seoTitle' | 'seoDescription' | 'name' | 'description' | 'longDescription' | 'productType' | 'slug' | 'category' | 'created' | 'updatedAt' | 'chargeTaxes' | 'weight' | 'defaultVariant' | 'rating' | 'channel' | 'descriptionJson' | 'longDescriptionJson' | 'thumbnail' | 'pricing' | 'isAvailable' | 'taxType' | 'attributes' | 'channelListings' | 'mediaById' | 'imageById' | 'variants' | 'media' | 'images' | 'collections' | 'translation' | 'availableForPurchase' | 'availableForPurchaseAt' | 'isAvailableForPurchase' | ProductKeySpecifier)[];
 export type ProductFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2969,6 +2969,7 @@ export type ProductFieldPolicy = {
 	rating?: FieldPolicy<any> | FieldReadFunction<any>,
 	channel?: FieldPolicy<any> | FieldReadFunction<any>,
 	descriptionJson?: FieldPolicy<any> | FieldReadFunction<any>,
+	longDescriptionJson?: FieldPolicy<any> | FieldReadFunction<any>,
 	thumbnail?: FieldPolicy<any> | FieldReadFunction<any>,
 	pricing?: FieldPolicy<any> | FieldReadFunction<any>,
 	isAvailable?: FieldPolicy<any> | FieldReadFunction<any>,


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
https://bandieramonte.atlassian.net/browse/WEB-21

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
